### PR TITLE
Revamp styling for UPA 2025 branding

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="h-full">
-      <body className={`${inter.className} h-full bg-gray-50 dark:bg-gray-900`}>
+      <body
+        className={`${inter.className} h-full bg-gradient-to-b from-navy to-blue`}
+      >
         <Layout>{children}</Layout>
       </body>
     </html>

--- a/src/app/teams/[id]/not-found.tsx
+++ b/src/app/teams/[id]/not-found.tsx
@@ -2,17 +2,17 @@ import Link from 'next/link';
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col justify-center items-center px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex flex-col justify-center items-center px-4 sm:px-6 lg:px-8">
       <div className="text-center">
-        <h1 className="text-6xl font-bold text-indigo-600 dark:text-indigo-400">404</h1>
-        <h2 className="mt-4 text-3xl font-extrabold text-gray-900 dark:text-white">Team not found</h2>
-        <p className="mt-4 text-lg text-gray-500 dark:text-gray-300">
+        <h1 className="text-6xl font-bold text-gold">404</h1>
+        <h2 className="mt-4 text-3xl font-extrabold text-white drop-shadow">Team not found</h2>
+        <p className="mt-4 text-lg text-white/80">
           Sorry, we couldn't find the team you're looking for.
         </p>
         <div className="mt-8">
           <Link
             href="/teams"
-            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:bg-indigo-700 dark:hover:bg-indigo-600"
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue hover:bg-blue/80"
           >
             Browse Teams
           </Link>

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -187,7 +187,7 @@ export default async function TeamPage({ params }: PageProps) {
     };
 
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
+      <div className="min-h-screen transition-colors duration-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <TeamHeader team={team} />
           

--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -50,10 +50,10 @@ export default async function TeamsPage() {
   const teams = await getTeams();
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
-          <h1 className="text-4xl font-extrabold text-gray-900 dark:text-white sm:text-5xl sm:tracking-tight lg:text-6xl">
+          <h1 className="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-6xl drop-shadow">
             UPA Summer Championship
           </h1>
           <p className="mt-3 max-w-2xl mx-auto text-xl text-gray-500 dark:text-gray-300 sm:mt-4">
@@ -66,7 +66,7 @@ export default async function TeamsPage() {
             <Link
               key={team.id}
               href={`/teams/${team.id}`}
-              className="col-span-1 bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden hover:shadow-lg transition-shadow duration-200"
+              className="col-span-1 bg-white rounded-lg shadow-sun overflow-hidden hover:shadow-lg transition-shadow duration-200"
             >
               <div className="p-6">
                 <div className="flex items-center">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -27,19 +27,19 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="bg-white dark:bg-gray-800 shadow-sm">
+      <header className="bg-gradient-to-r from-navy to-blue shadow-lg">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16">
             <div className="flex">
               <div className="flex-shrink-0 flex items-center">
-                <Link href="/" className="text-xl font-bold text-indigo-600 dark:text-indigo-400">
+                <Link href="/" className="text-2xl font-extrabold text-white drop-shadow">
                   UPA Summer Championship
                 </Link>
               </div>
               <nav className="hidden sm:ml-6 sm:flex sm:space-x-8">
                 <Link
                   href="/teams"
-                  className={`${pathname === '/teams' ? 'border-indigo-500 text-gray-900 dark:text-white' : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-300'} inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium`}
+                  className={`${pathname === '/teams' ? 'border-gold text-white' : 'border-transparent text-white/70 hover:border-gold hover:text-white'} inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium`}
                 >
                   Teams
                 </Link>
@@ -49,7 +49,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
               <button
                 type="button"
                 onClick={toggleDarkMode}
-                className="p-2 rounded-full text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"
+                className="p-2 rounded-full text-gold hover:text-orange focus:outline-none focus:ring-2 focus:ring-orange"
               >
                 <span className="sr-only">Toggle dark mode</span>
                 {darkMode ? (
@@ -63,9 +63,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         </div>
       </header>
       <main className="flex-grow">{children}</main>
-      <footer className="bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 mt-8">
+      <footer className="bg-navy border-t border-blue mt-8 text-white">
         <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-          <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-center text-sm text-white/80">
             &copy; {new Date().getFullYear()} UPA Summer Championship. All rights reserved.
           </p>
         </div>

--- a/src/components/TeamHeader.tsx
+++ b/src/components/TeamHeader.tsx
@@ -20,10 +20,10 @@ interface TeamHeaderProps {
 
 export default function TeamHeader({ team }: TeamHeaderProps) {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+    <div className="bg-gradient-to-r from-navy to-blue rounded-lg shadow-sun overflow-hidden">
       <div className="px-6 py-8 sm:flex sm:items-center sm:justify-between">
         <div className="flex items-center">
-          <div className="flex-shrink-0 h-24 w-24 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center overflow-hidden">
+          <div className="flex-shrink-0 h-24 w-24 rounded-full bg-gray-200 flex items-center justify-center overflow-hidden shadow-sun">
             {team.logo_url ? (
               <Image 
                 src={team.logo_url} 
@@ -41,11 +41,11 @@ export default function TeamHeader({ team }: TeamHeaderProps) {
           </div>
           <div className="ml-6">
             <div className="flex items-center space-x-4">
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+              <h1 className="text-3xl font-extrabold text-white drop-shadow">
                 {team.name}
               </h1>
               {team.leaderboard_tier && (
-                <span className="px-2 py-1 text-xs font-semibold rounded-full bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100">
+                <span className="px-2 py-1 text-xs font-semibold rounded-full bg-gold text-navy">
                   {team.leaderboard_tier}
                 </span>
               )}
@@ -54,11 +54,11 @@ export default function TeamHeader({ team }: TeamHeaderProps) {
             <div className="mt-2 space-y-3">
               {team.region && (
                 <div className="flex items-center">
-                  <span className="text-lg text-gray-500 dark:text-gray-300">
+                  <span className="text-lg text-white/80">
                     {team.region.name}
                   </span>
                   {team.leaderboard_tier && (
-                    <span className="ml-3 px-2 py-0.5 text-xs font-medium rounded-full bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-200">
+                    <span className="ml-3 px-2 py-0.5 text-xs font-medium rounded-full bg-gold text-navy">
                       {team.leaderboard_tier}
                     </span>
                   )}
@@ -66,33 +66,33 @@ export default function TeamHeader({ team }: TeamHeaderProps) {
               )}
               
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-                <div className="bg-gray-50 dark:bg-gray-700/50 p-3 rounded-lg">
-                  <div className="text-xs font-medium text-gray-500 dark:text-gray-400">Ranking Points</div>
-                  <div className="text-lg font-bold text-indigo-600 dark:text-indigo-400">
+                <div className="bg-white/20 p-3 rounded-lg">
+                  <div className="text-xs font-medium text-white/80">Ranking Points</div>
+                  <div className="text-lg font-bold text-gold">
                     {team.current_rp?.toLocaleString() || 'N/A'}
                   </div>
                 </div>
-                
-                <div className="bg-gray-50 dark:bg-gray-700/50 p-3 rounded-lg">
-                  <div className="text-xs font-medium text-gray-500 dark:text-gray-400">ELO Rating</div>
-                  <div className="text-lg font-bold text-indigo-600 dark:text-indigo-400">
+
+                <div className="bg-white/20 p-3 rounded-lg">
+                  <div className="text-xs font-medium text-white/80">ELO Rating</div>
+                  <div className="text-lg font-bold text-gold">
                     {team.elo_rating ? Math.round(team.elo_rating) : 'N/A'}
                   </div>
                 </div>
                 
                 {team.global_rank && (
-                  <div className="bg-gray-50 dark:bg-gray-700/50 p-3 rounded-lg">
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400">Global Rank</div>
-                    <div className="text-lg font-bold text-indigo-600 dark:text-indigo-400">
+                  <div className="bg-white/20 p-3 rounded-lg">
+                    <div className="text-xs font-medium text-white/80">Global Rank</div>
+                    <div className="text-lg font-bold text-gold">
                       #{team.global_rank.toLocaleString()}
                     </div>
                   </div>
                 )}
                 
                 {team.stats && (
-                  <div className="bg-gray-50 dark:bg-gray-700/50 p-3 rounded-lg">
-                    <div className="text-xs font-medium text-gray-500 dark:text-gray-400">Record</div>
-                    <div className="text-lg font-bold text-indigo-600 dark:text-indigo-400">
+                  <div className="bg-white/20 p-3 rounded-lg">
+                    <div className="text-xs font-medium text-white/80">Record</div>
+                    <div className="text-lg font-bold text-gold">
                       {team.stats.wins}-{team.stats.losses}{team.stats.games_played > team.stats.wins + team.stats.losses ? `-${team.stats.games_played - team.stats.wins - team.stats.losses}` : ''}
                     </div>
                   </div>
@@ -103,9 +103,9 @@ export default function TeamHeader({ team }: TeamHeaderProps) {
         </div>
         
         <div className="mt-4 sm:mt-0 flex flex-wrap gap-3">
-          <button 
+          <button
             type="button"
-            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:bg-indigo-700 dark:hover:bg-indigo-600 transition-colors duration-200"
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue hover:bg-blue/80 transition-colors"
           >
             <svg className="-ml-1 mr-2 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
@@ -114,11 +114,11 @@ export default function TeamHeader({ team }: TeamHeaderProps) {
             View Stats
           </button>
           
-          <button 
+          <button
             type="button"
-            className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md shadow-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors duration-200"
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-gold hover:bg-orange transition-colors"
           >
-            <svg className="-ml-1 mr-2 h-5 w-5 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <svg className="-ml-1 mr-2 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47C13.456 7.68 14.19 8 15 8z" />
             </svg>
             Share
@@ -126,9 +126,9 @@ export default function TeamHeader({ team }: TeamHeaderProps) {
           
           <a
             href={`/teams/${team.id}/matches`}
-            className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md shadow-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors duration-200"
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue hover:bg-blue/80 transition-colors"
           >
-            <svg className="-ml-1 mr-2 h-5 w-5 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <svg className="-ml-1 mr-2 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
             </svg>
             Match History
@@ -136,9 +136,9 @@ export default function TeamHeader({ team }: TeamHeaderProps) {
           
           <a
             href={`/teams/${team.id}/roster`}
-            className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 text-sm font-medium rounded-md shadow-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors duration-200"
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-gold hover:bg-orange transition-colors"
           >
-            <svg className="-ml-1 mr-2 h-5 w-5 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <svg className="-ml-1 mr-2 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v1h8v-1zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-1a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v1h-3zM4.75 12.094A5.973 5.973 0 004 15v1H1v-1a3 3 0 013.75-2.906z" />
             </svg>
             View Roster

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -26,14 +26,14 @@ export default function TeamStats({ team }: TeamStatsProps) {
   
   if (!stats) {
     return (
-      <div className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg">
-        <div className="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700">
-          <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
+      <div className="bg-navy/80 shadow-sun overflow-hidden sm:rounded-lg">
+        <div className="px-4 py-5 sm:px-6 border-b border-blue">
+          <h3 className="text-lg leading-6 font-extrabold text-white drop-shadow">
             Team Statistics
           </h3>
         </div>
         <div className="px-4 py-12 text-center">
-          <p className="text-gray-500 dark:text-gray-400">No statistics available yet</p>
+          <p className="text-white/80">No statistics available yet</p>
         </div>
       </div>
     );
@@ -112,25 +112,25 @@ export default function TeamStats({ team }: TeamStatsProps) {
     switch (result) {
       case 'W':
         return (
-          <div key={index} className={`${baseClasses} bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200`}>
+          <div key={index} className={`${baseClasses} bg-green-500 text-white`}>
             W
           </div>
         );
       case 'L':
         return (
-          <div key={index} className={`${baseClasses} bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200`}>
+          <div key={index} className={`${baseClasses} bg-red text-white`}>
             L
           </div>
         );
       case 'D':
         return (
-          <div key={index} className={`${baseClasses} bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200`}>
+          <div key={index} className={`${baseClasses} bg-gold text-navy`}>
             D
           </div>
         );
       default:
         return (
-          <div key={index} className={`${baseClasses} bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300`}>
+          <div key={index} className={`${baseClasses} bg-blue text-white`}>
             —
           </div>
         );
@@ -138,20 +138,20 @@ export default function TeamStats({ team }: TeamStatsProps) {
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg">
-      <div className="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+    <div className="bg-navy/80 shadow-sun overflow-hidden sm:rounded-lg">
+      <div className="px-4 py-5 sm:px-6 border-b border-blue flex justify-between items-center">
         <div>
-          <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
+          <h3 className="text-lg leading-6 font-extrabold text-white drop-shadow">
             Team Statistics
           </h3>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          <p className="mt-1 text-sm text-white/80">
             Season {new Date().getFullYear()} performance metrics
           </p>
         </div>
         
         {stats.form_last_5 && stats.form_last_5.length > 0 && (
           <div className="flex items-center space-x-1">
-            <span className="text-sm font-medium text-gray-500 dark:text-gray-400 mr-2">Form:</span>
+            <span className="text-sm font-medium text-white/80 mr-2">Form:</span>
             {stats.form_last_5.map((result, index) => renderFormIndicator(result, index))}
           </div>
         )}
@@ -162,21 +162,21 @@ export default function TeamStats({ team }: TeamStatsProps) {
           {statsList.map((item) => (
             <div 
               key={item.name} 
-              className="px-4 py-5 bg-gray-50 dark:bg-gray-700 rounded-lg overflow-hidden sm:p-6 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors duration-150"
+              className="px-4 py-5 bg-white/10 rounded-lg overflow-hidden sm:p-6 hover:bg-white/20 transition-colors duration-150"
               title={item.description}
             >
               <div className="flex items-center">
                 <span className="text-lg mr-2" aria-hidden="true">{item.icon}</span>
-                <dt className="text-sm font-medium text-gray-500 dark:text-gray-300 truncate">
+                <dt className="text-sm font-medium text-white/80 truncate">
                   {item.name}
                 </dt>
               </div>
               <div className="mt-2 flex items-baseline">
-                <dd className="text-2xl font-semibold text-gray-900 dark:text-white">
+                <dd className="text-2xl font-semibold text-white">
                   {item.value}
                 </dd>
                 {item.change !== undefined && item.change !== 0 && (
-                  <span className={`ml-2 text-sm font-medium ${item.change >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                  <span className={`ml-2 text-sm font-medium ${item.change >= 0 ? 'text-green-300' : 'text-red-300'}`}>
                     {item.change > 0 ? '↑' : '↓'} {Math.abs(item.change)}
                   </span>
                 )}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        navy: '#081C3C',
+        blue: '#0070CE',
+        gold: '#FFC72C',
+        orange: '#FF5F1F',
+        red: '#C8102E',
+      },
+      boxShadow: {
+        sun: '0 0 20px rgba(255,199,44,0.6)',
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind config with custom championship colors
- switch global layout to use navy→blue gradient
- update header, buttons and cards with gold/blue accents
- redesign team header and stats components
- tweak not-found page to match new theme

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ed709c7083288076e345e5277cc7