### PR TITLE
Refactor for UPA Summer Championships

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# UPA Summer Championship
+# UPA Summer Championships
 
-A modern web application for tracking teams, players, and matches in the UPA Summer Championship. Built with Next.js 14, TypeScript, Tailwind CSS, and Supabase.
+A modern web application for tracking teams, players, and matches in the UPA Summer Championships, an NBA 2K Pro Am tournament. Built with Next.js 14, TypeScript, Tailwind CSS, and Supabase.
 
 ## Features
 

--- a/scripts/setup-db.sh
+++ b/scripts/setup-db.sh
@@ -19,7 +19,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-echo -e "${YELLOW}Setting up UPA Summer Championship database...${NC}"
+echo -e "${YELLOW}Setting up UPA Summer Championships database...${NC}"
 
 # Function to run SQL files
 run_sql_file() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,8 +14,8 @@ export const viewport = {
 };
 
 export const metadata: Metadata = {
-  title: 'UPA Summer Championship',
-  description: 'Track your favorite teams and players in the UPA Summer Championship',
+  title: 'UPA Summer Championships',
+  description: 'Track your favorite teams and players in the UPA Summer Championships',
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,160 @@
-import Image from "next/image";
+import { supabase } from '@/utils/supabase';
+import Image from 'next/image';
+import { format } from 'date-fns';
+import Link from 'next/link';
 
-export default function Home() {
+interface MatchWithTeams {
+  id: string;
+  team_a?: { id: string; name: string; logo_url: string | null };
+  team_b?: { id: string; name: string; logo_url: string | null };
+  score_a?: number | null;
+  score_b?: number | null;
+  played_at?: string | null;
+  status?: string | null;
+}
+
+async function getRecentMatches(): Promise<MatchWithTeams[]> {
+  const { data, error } = await supabase
+    .from('matches')
+    .select(
+      `id, team_a_id, team_b_id, score_a, score_b, played_at, status,
+       team_a:team_a_id (id, name, logo_url),
+       team_b:team_b_id (id, name, logo_url)`
+    )
+    .eq('status', 'completed')
+    .order('played_at', { ascending: false })
+    .limit(5);
+
+  if (error) {
+    console.error('Error fetching recent matches', error);
+    return [];
+  }
+  return data || [];
+}
+
+async function getUpcomingMatches(): Promise<MatchWithTeams[]> {
+  const { data, error } = await supabase
+    .from('matches')
+    .select(
+      `id, team_a_id, team_b_id, score_a, score_b, played_at, status,
+       team_a:team_a_id (id, name, logo_url),
+       team_b:team_b_id (id, name, logo_url)`
+    )
+    .eq('status', 'scheduled')
+    .order('played_at', { ascending: true })
+    .limit(5);
+
+  if (error) {
+    console.error('Error fetching upcoming matches', error);
+    return [];
+  }
+  return data || [];
+}
+
+export default async function Home() {
+  const [recent, upcoming] = await Promise.all([getRecentMatches(), getUpcomingMatches()]);
+
+  const renderMatch = (m: MatchWithTeams) => {
+    const date = m.played_at ? new Date(m.played_at) : null;
+    const score = m.score_a !== null && m.score_b !== null ? (
+      <span className="font-mono">{m.score_a}-{m.score_b}</span>
+    ) : (
+      <span className="text-gray-400">vs</span>
+    );
+
+    return (
+      <tr key={m.id} className="border-t border-gray-200 dark:border-gray-700">
+        <td className="px-4 py-2">
+          <div className="flex items-center space-x-2">
+            {m.team_a?.logo_url ? (
+              <Image src={m.team_a.logo_url} alt={m.team_a.name} width={24} height={24} className="rounded-full" unoptimized />
+            ) : (
+              <div className="w-6 h-6 rounded-full bg-gray-300 flex items-center justify-center text-xs">{m.team_a?.name[0]}</div>
+            )}
+            <span>{m.team_a?.name}</span>
+          </div>
+        </td>
+        <td className="px-4 py-2">
+          <div className="flex items-center space-x-2">
+            {m.team_b?.logo_url ? (
+              <Image src={m.team_b.logo_url} alt={m.team_b.name} width={24} height={24} className="rounded-full" unoptimized />
+            ) : (
+              <div className="w-6 h-6 rounded-full bg-gray-300 flex items-center justify-center text-xs">{m.team_b?.name[0]}</div>
+            )}
+            <span>{m.team_b?.name}</span>
+          </div>
+        </td>
+        <td className="px-4 py-2 text-center">{score}</td>
+        <td className="px-4 py-2 text-right">{date ? format(date, 'MMM d, h:mm a') : 'TBD'}</td>
+      </tr>
+    );
+  };
+
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+    <div className="max-w-5xl mx-auto p-6 space-y-12">
+      <section className="text-center space-y-4">
+        <h1 className="text-4xl font-extrabold text-white drop-shadow">UPA Summer Championships</h1>
+        <p className="text-lg text-gray-200">NBA 2K Pro Am Tournament</p>
+      </section>
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+      <section className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+        <div className="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">Recent Results</h2>
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">Home</th>
+              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">Away</th>
+              <th className="px-4 py-2 text-center text-xs font-medium text-gray-500 dark:text-gray-300">Score</th>
+              <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-300">Played</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {recent.map(renderMatch)}
+            {recent.length === 0 && (
+              <tr><td colSpan={4} className="px-4 py-6 text-center text-gray-500">No recent matches</td></tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+        <div className="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">Upcoming Schedule</h2>
+        </div>
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">Home</th>
+              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300">Away</th>
+              <th className="px-4 py-2 text-center text-xs font-medium text-gray-500 dark:text-gray-300">Score</th>
+              <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-300">Tip Off</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {upcoming.map(renderMatch)}
+            {upcoming.length === 0 && (
+              <tr><td colSpan={4} className="px-4 py-6 text-center text-gray-500">No upcoming games</td></tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="space-y-4 text-center">
+        <h2 className="text-2xl font-bold text-white drop-shadow">Sponsors</h2>
+        <p className="text-gray-200">Thanks to our amazing partners for supporting the UPA Summer Championships.</p>
+        <div className="flex justify-center space-x-8">
+          <span className="text-gray-300">Sponsor 1</span>
+          <span className="text-gray-300">Sponsor 2</span>
+          <span className="text-gray-300">Sponsor 3</span>
+        </div>
+      </section>
+
+      <section className="space-y-2 text-center">
+        <h2 className="text-2xl font-bold text-white drop-shadow">Organized by UPA</h2>
+        <p className="text-gray-200">For inquiries contact info@unitedproam.gg</p>
+      </section>
     </div>
   );
 }

--- a/src/app/teams/[id]/page.tsx
+++ b/src/app/teams/[id]/page.tsx
@@ -111,13 +111,20 @@ async function getTeamData(id: string): Promise<TeamWithRoster | null> {
              (match.team_b_id === teamData.id && scoreB > scoreA);
     }).length || 0;
     
-    const totalPoints = matchesData?.reduce((sum, match) => {
-      return match.team_a_id === teamData.id 
-        ? sum + (match.score_a || 0) 
+    const totalPointsFor = matchesData?.reduce((sum, match) => {
+      return match.team_a_id === teamData.id
+        ? sum + (match.score_a || 0)
         : sum + (match.score_b || 0);
     }, 0) || 0;
 
-    const avgPoints = gamesPlayed > 0 ? Math.round((totalPoints / gamesPlayed) * 10) / 10 : 0;
+    const totalPointsAgainst = matchesData?.reduce((sum, match) => {
+      return match.team_a_id === teamData.id
+        ? sum + (match.score_b || 0)
+        : sum + (match.score_a || 0);
+    }, 0) || 0;
+
+    const avgPoints = gamesPlayed > 0 ? Math.round((totalPointsFor / gamesPlayed) * 10) / 10 : 0;
+    const avgPointsAgainst = gamesPlayed > 0 ? Math.round((totalPointsAgainst / gamesPlayed) * 10) / 10 : 0;
 
     return {
       ...teamData,
@@ -138,6 +145,7 @@ async function getTeamData(id: string): Promise<TeamWithRoster | null> {
       stats: {
         games_played: gamesPlayed,
         avg_points: avgPoints,
+        avg_points_against: avgPointsAgainst,
         wins: wins,
         losses: gamesPlayed - wins
       }
@@ -174,11 +182,10 @@ export default async function TeamPage({ params }: PageProps) {
         games_played: team.stats.games_played,
         wins: team.stats.wins,
         losses: team.stats.losses,
-        draws: 0, // This would come from your data if you track draws
-        goals_for: 0, // Update if you track goals
-        goals_against: 0, // Update if you track goals against
-        current_streak: 0, // Update if you track streaks
-        form_last_5: [] // Update if you track form
+        avg_points: team.stats.avg_points,
+        avg_points_against: team.stats.avg_points_against,
+        current_streak: 0,
+        form_last_5: []
       },
       // Add RP and ELO info if available
       team_rp: team.current_rp || 0,

--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -54,7 +54,7 @@ export default async function TeamsPage() {
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-12">
           <h1 className="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-6xl drop-shadow">
-            UPA Summer Championship
+            UPA Summer Championships
           </h1>
           <p className="mt-3 max-w-2xl mx-auto text-xl text-gray-500 dark:text-gray-300 sm:mt-4">
             Explore teams and track their progress throughout the season

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -33,7 +33,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             <div className="flex">
               <div className="flex-shrink-0 flex items-center">
                 <Link href="/" className="text-2xl font-extrabold text-white drop-shadow">
-                  UPA Summer Championship
+                  UPA Summer Championships
                 </Link>
               </div>
               <nav className="hidden sm:ml-6 sm:flex sm:space-x-8">
@@ -66,7 +66,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <footer className="bg-navy border-t border-blue mt-8 text-white">
         <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
           <p className="text-center text-sm text-white/80">
-            &copy; {new Date().getFullYear()} UPA Summer Championship. All rights reserved.
+            &copy; {new Date().getFullYear()} UPA Summer Championships. All rights reserved.
           </p>
         </div>
       </footer>

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -12,9 +12,8 @@ interface TeamStatsProps {
       games_played: number;
       wins: number;
       losses: number;
-      draws: number;
-      goals_for: number;
-      goals_against: number;
+      avg_points: number;
+      avg_points_against: number;
       current_streak: number;
       form_last_5: string[];
     };
@@ -43,13 +42,9 @@ export default function TeamStats({ team }: TeamStatsProps) {
     ? Math.round((stats.wins / stats.games_played) * 100) 
     : 0;
   
-  const goalDifference = stats.goals_for - stats.goals_against;
-  const avgGoalsFor = stats.games_played > 0 
-    ? (stats.goals_for / stats.games_played).toFixed(1) 
-    : 0;
-  const avgGoalsAgainst = stats.games_played > 0 
-    ? (stats.goals_against / stats.games_played).toFixed(1) 
-    : 0;
+  const avgPoints = stats.avg_points.toFixed(1);
+  const avgPointsAgainst = stats.avg_points_against.toFixed(1);
+  const pointDiff = (stats.avg_points - stats.avg_points_against).toFixed(1);
 
   const statsList = [
     { 
@@ -68,9 +63,9 @@ export default function TeamStats({ team }: TeamStatsProps) {
     },
     { 
       name: 'Record', 
-      value: `${stats.wins}-${stats.losses}${stats.draws > 0 ? `-${stats.draws}` : ''}`,
+      value: `${stats.wins}-${stats.losses}`,
       icon: '📈',
-      description: 'Win-Loss-Draw record'
+      description: 'Win-Loss record'
     },
     { 
       name: 'Win %', 
@@ -78,11 +73,11 @@ export default function TeamStats({ team }: TeamStatsProps) {
       icon: '🎯',
       description: 'Win percentage'
     },
-    { 
-      name: 'Goal Difference', 
-      value: goalDifference > 0 ? `+${goalDifference}` : goalDifference,
-      icon: '⚽',
-      description: 'Goals for minus goals against'
+    {
+      name: 'Point Differential',
+      value: pointDiff,
+      icon: '🏀',
+      description: 'Average points scored minus allowed'
     },
     { 
       name: 'Current Streak', 
@@ -93,16 +88,16 @@ export default function TeamStats({ team }: TeamStatsProps) {
       description: 'Current win/loss streak'
     },
     { 
-      name: 'Avg. Goals For', 
-      value: avgGoalsFor,
+      name: 'Avg. Points For',
+      value: avgPoints,
       icon: '⬆️',
-      description: 'Average goals scored per game'
+      description: 'Average points scored per game'
     },
-    { 
-      name: 'Avg. Goals Against', 
-      value: avgGoalsAgainst,
+    {
+      name: 'Avg. Points Against',
+      value: avgPointsAgainst,
       icon: '⬇️',
-      description: 'Average goals conceded per game'
+      description: 'Average points allowed per game'
     },
   ];
 


### PR DESCRIPTION
## Summary
- rename project references to **UPA Summer Championships**
- rewrite the homepage to display recent results, upcoming schedule, sponsors and organizer info
- add basketball-focused stats on team pages
- compute average points for and against when fetching team data
- update setup script and documentation

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6878f351eefc8328b8ba794b5eb25f93