### PR TITLE
Refactor UI with MUI components

### DIFF
--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -1,6 +1,14 @@
 import { supabase } from '@/utils/supabase';
 import Link from 'next/link';
-import Image from 'next/image';
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Avatar,
+  Chip,
+  Grid,
+  Typography,
+} from '@mui/material';
 
 export const revalidate = 3600; // Revalidate data every hour
 
@@ -50,73 +58,49 @@ export default async function TeamsPage() {
   const teams = await getTeams();
 
   return (
-    <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-7xl mx-auto">
-        <div className="text-center mb-12">
-          <h1 className="text-4xl font-extrabold text-white sm:text-5xl sm:tracking-tight lg:text-6xl drop-shadow">
+    <div style={{ minHeight: '100vh', padding: '3rem 1rem' }}>
+      <div style={{ maxWidth: 1120, margin: '0 auto' }}>
+        <div style={{ textAlign: 'center', marginBottom: '3rem' }}>
+          <Typography variant="h3" component="h1" gutterBottom sx={{ fontWeight: 'bold', color: 'primary.contrastText' }}>
             UPA Summer Championships
-          </h1>
-          <p className="mt-3 max-w-2xl mx-auto text-xl text-gray-500 dark:text-gray-300 sm:mt-4">
+          </Typography>
+          <Typography variant="h6" sx={{ color: 'text.secondary', maxWidth: 560, margin: '0 auto' }}>
             Explore teams and track their progress throughout the season
-          </p>
+          </Typography>
         </div>
 
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {teams.map((team) => (
-            <Link
-              key={team.id}
-              href={`/teams/${team.id}`}
-              className="col-span-1 bg-white rounded-lg shadow-sun overflow-hidden hover:shadow-lg transition-shadow duration-200"
-            >
-              <div className="p-6">
-                <div className="flex items-center">
-                  <div className="flex-shrink-0 h-16 w-16 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center overflow-hidden">
-                    {team.logo_url ? (
-                      <Image
-                        width={64}
-                        height={64}
-                        className="h-16 w-16 object-cover"
-                        src={team.logo_url}
-                        alt={`${team.name} logo`}
-                        unoptimized
-                      />
+        <Grid container spacing={2}>
+          {teams.map(team => (
+            <Grid item xs={12} sm={6} md={3} key={team.id}>
+              <Card component={Link} href={`/teams/${team.id}`} sx={{ textDecoration: 'none', boxShadow: '0 0 10px rgba(246,216,96,0.4)', height: '100%' }}>
+                <CardHeader
+                  avatar={
+                    team.logo_url ? (
+                      <Avatar src={team.logo_url} imgProps={{ referrerPolicy: 'no-referrer' }} />
                     ) : (
-                      <span className="text-2xl font-bold text-gray-400">
-                        {team.name.charAt(0).toUpperCase()}
-                      </span>
-                    )}
-                  </div>
-                  <div className="ml-4">
-                    <h3 className="text-lg font-medium text-gray-900 dark:text-white">
-                      {team.name}
-                    </h3>
-                    <div className="space-y-1">
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        {team.regions?.[0]?.name || 'No region'}
-                      </p>
-                      <div className="flex items-center space-x-2">
-                        <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 rounded-full dark:bg-blue-900 dark:text-blue-200">
-                          ELO: {team.elo_rating?.toFixed(0) || 'N/A'}
-                        </span>
-                        {team.current_rp !== null && (
-                          <span className="px-2 py-0.5 text-xs font-medium bg-green-100 text-green-800 rounded-full dark:bg-green-900 dark:text-green-200">
-                            {team.current_rp} RP
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </Link>
+                      <Avatar>{team.name.charAt(0).toUpperCase()}</Avatar>
+                    )
+                  }
+                  title={<Typography variant="h6">{team.name}</Typography>}
+                  subheader={team.regions?.[0]?.name || 'No region'}
+                />
+                <CardContent>
+                  <Chip label={`ELO: ${team.elo_rating?.toFixed(0) || 'N/A'}`} size="small" sx={{ mr: 1 }} />
+                  {team.current_rp !== null && (
+                    <Chip label={`${team.current_rp} RP`} size="small" color="secondary" />
+                  )}
+                  {team.leaderboard_tier && (
+                    <Chip label={team.leaderboard_tier} size="small" sx={{ ml: 1 }} />
+                  )}
+                </CardContent>
+              </Card>
+            </Grid>
           ))}
-        </div>
+        </Grid>
 
         {teams.length === 0 && (
-          <div className="text-center py-12">
-            <p className="text-gray-500 dark:text-gray-400">
-              No teams found. Check back later for updates.
-            </p>
+          <div style={{ textAlign: 'center', padding: '3rem 0' }}>
+            <Typography color="text.secondary">No teams found. Check back later for updates.</Typography>
           </div>
         )}
       </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useContext } from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import AppBar from '@mui/material/AppBar';
@@ -10,26 +10,11 @@ import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import { LightMode, DarkMode } from '@mui/icons-material';
+import { ColorModeContext } from './MuiThemeProvider';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  const [darkMode, setDarkMode] = useState(false);
+  const { toggleColorMode, mode } = useContext(ColorModeContext);
   const pathname = usePathname();
-
-  // Initialize dark mode from localStorage or system preference
-  useEffect(() => {
-    const isDark = localStorage.getItem('darkMode') === 'true' || 
-      (!('darkMode' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches);
-    
-    setDarkMode(isDark);
-    document.documentElement.classList.toggle('dark', isDark);
-  }, []);
-
-  const toggleDarkMode = () => {
-    const newMode = !darkMode;
-    setDarkMode(newMode);
-    localStorage.setItem('darkMode', String(newMode));
-    document.documentElement.classList.toggle('dark', newMode);
-  };
 
   return (
     <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
@@ -55,8 +40,8 @@ export default function Layout({ children }: { children: React.ReactNode }) {
               Teams
             </Typography>
           </Box>
-          <IconButton color="inherit" onClick={toggleDarkMode} aria-label="Toggle dark mode">
-            {darkMode ? <LightMode /> : <DarkMode />}
+          <IconButton color="inherit" onClick={toggleColorMode} aria-label="Toggle dark mode">
+            {mode === 'dark' ? <LightMode /> : <DarkMode />}
           </IconButton>
         </Toolbar>
       </AppBar>

--- a/src/components/MuiThemeProvider.tsx
+++ b/src/components/MuiThemeProvider.tsx
@@ -1,33 +1,54 @@
 'use client';
-import { createTheme, ThemeProvider, CssBaseline } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { createTheme, ThemeProvider, CssBaseline, responsiveFontSizes } from '@mui/material';
+import { createContext, useEffect, useMemo, useState } from 'react';
+
+export const ColorModeContext = createContext<{ toggleColorMode: () => void; mode: 'light' | 'dark'; }>({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  toggleColorMode: () => {},
+  mode: 'light',
+});
 
 export default function MuiThemeProvider({ children }: { children: React.ReactNode }) {
   const [mode, setMode] = useState<'light' | 'dark'>('light');
 
   useEffect(() => {
     const saved = localStorage.getItem('darkMode');
-    if (saved === 'true' || (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-      setMode('dark');
-    }
+    const isDark = saved === 'true' || (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    setMode(isDark ? 'dark' : 'light');
+    document.documentElement.classList.toggle('dark', isDark);
   }, []);
 
-  const theme = useMemo(
-    () =>
-      createTheme({
-        palette: {
-          mode,
-          primary: { main: '#0b2a4a' },
-          secondary: { main: '#f6d860' },
+  const toggleColorMode = () => {
+    setMode(prev => {
+      const next = prev === 'light' ? 'dark' : 'light';
+      localStorage.setItem('darkMode', String(next === 'dark'));
+      document.documentElement.classList.toggle('dark', next === 'dark');
+      return next;
+    });
+  };
+
+  const theme = useMemo(() => {
+    let t = createTheme({
+      palette: {
+        mode,
+        primary: { main: '#0b2a4a' },
+        secondary: { main: '#f6d860' },
+        background: {
+          default: '#fefefe',
+          paper: '#ffffff',
         },
-      }),
-    [mode],
-  );
+      },
+    });
+    t = responsiveFontSizes(t);
+    return t;
+  }, [mode]);
 
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      {children}
-    </ThemeProvider>
+    <ColorModeContext.Provider value={{ toggleColorMode, mode }}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </ColorModeContext.Provider>
   );
 }

--- a/src/components/RosterTable.tsx
+++ b/src/components/RosterTable.tsx
@@ -1,7 +1,22 @@
 'use client';
 
-import { useState, useMemo } from 'react';
-import Image from 'next/image';
+import React, { useState, useMemo } from 'react';
+import {
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  TableSortLabel,
+  TextField,
+  InputAdornment,
+  Avatar,
+  Chip,
+  Paper,
+  Typography,
+  Box,
+} from '@mui/material';
+import { Search } from '@mui/icons-material';
 import type { Player as BasePlayer } from '@/utils/supabase';
 
 type Player = BasePlayer & {
@@ -31,9 +46,9 @@ interface RosterTableProps {
 }
 
 export default function RosterTable({ players }: RosterTableProps) {
-  const [sortConfig, setSortConfig] = useState<SortConfig>({ 
-    key: 'gamertag', 
-    direction: 'asc' 
+  const [sortConfig, setSortConfig] = useState<SortConfig>({
+    key: 'gamertag',
+    direction: 'asc',
   });
   
   const [searchTerm, setSearchTerm] = useState('');
@@ -70,71 +85,21 @@ export default function RosterTable({ players }: RosterTableProps) {
       direction: prev.key === key && prev.direction === 'asc' ? 'desc' : 'asc'
     }));
   };
-
-
   const getStatusBadge = (player: Player) => {
     const rosterInfo = player.team_rosters?.[0];
     if (!rosterInfo) return null;
-    
-    const badges = [];
-    
+    const badges: React.ReactNode[] = [];
     if (rosterInfo.is_captain) {
-      badges.push(
-        <span 
-          key="captain" 
-          className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200 border border-yellow-200 dark:border-yellow-800/50"
-          title="Team Captain"
-        >
-          <svg className="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-          </svg>
-          Captain
-        </span>
-      );
+      badges.push(<Chip key="captain" label="Captain" size="small" color="warning" sx={{ mr: 0.5 }} />);
     }
-    
     if (rosterInfo.is_player_coach) {
-      badges.push(
-        <span 
-          key="coach" 
-          className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-200 border border-purple-200 dark:border-purple-800/50"
-          title="Player Coach"
-        >
-          <svg className="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path d="M10 12a2 2 0 100-4 2 2 0 000 4z" />
-            <path fillRule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clipRule="evenodd" />
-          </svg>
-          Coach
-        </span>
-      );
+      badges.push(<Chip key="coach" label="Coach" size="small" color="secondary" sx={{ mr: 0.5 }} />);
     }
-    
-    // If no specific role badges, show Player
     if (badges.length === 0) {
-      badges.push(
-        <span 
-          key="player" 
-          className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200 border border-blue-200 dark:border-blue-800/50"
-          title="Team Player"
-        >
-          <svg className="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v1h8v-1zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-1a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v1h-3zM4.75 12.094A5.973 5.973 0 004 15v1H1v-1a3 3 0 013.75-2.906z" />
-          </svg>
-          Player
-        </span>
-      );
+      badges.push(<Chip key="player" label="Player" size="small" sx={{ mr: 0.5 }} />);
     }
-    
-    return (
-      <div className="flex flex-wrap gap-1.5">
-        {badges}
-      </div>
-    );
+    return <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>{badges}</Box>;
   };
-
-  const SortIndicator = ({ column, sortConfig }: { column: keyof Player; sortConfig: SortConfig }) => (
-    <span className="ml-1.5">
-      {sortConfig.key === column ? (
         sortConfig.direction === 'asc' ? (
           <svg className="w-3.5 h-3.5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
@@ -153,124 +118,89 @@ export default function RosterTable({ players }: RosterTableProps) {
   );
 
   return (
-    <div className="bg-white dark:bg-gray-800 shadow-lg rounded-lg overflow-hidden">
-      <div className="px-6 py-5 border-b border-gray-200 dark:border-gray-700">
-        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center space-y-4 sm:space-y-0">
-          <div>
-            <h3 className="text-xl font-semibold text-gray-900 dark:text-white">Team Roster</h3>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              {players.length} {players.length === 1 ? 'player' : 'players'} on roster
-            </p>
-          </div>
-          <div className="relative w-full sm:w-72">
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <svg className="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
-              </svg>
-            </div>
-            <input
-              type="text"
-              placeholder="Search players..."
-              className="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md leading-5 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm transition duration-150 ease-in-out"
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-            />
-          </div>
+    <Paper sx={{ overflowX: 'auto' }}>
+      <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider', display: 'flex', justifyContent: 'space-between', alignItems: { xs: 'flex-start', sm: 'center' }, flexDirection: { xs: 'column', sm: 'row' }, gap: 2 }}>
+        <div>
+          <Typography variant="h6">Team Roster</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {players.length} {players.length === 1 ? 'player' : 'players'} on roster
+          </Typography>
         </div>
-      </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-          <thead className="bg-gray-50 dark:bg-gray-700/50">
-            <tr>
-              <th 
-                scope="col" 
-                className="px-6 py-3.5 text-left text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors duration-150"
+        <TextField
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="Search players..."
+          size="small"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Search fontSize="small" />
+              </InputAdornment>
+            ),
+          }}
+          sx={{ width: { xs: '100%', sm: 250 } }}
+        />
+      </Box>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sortDirection={sortConfig.key === 'gamertag' ? sortConfig.direction : false}>
+              <TableSortLabel
+                active={sortConfig.key === 'gamertag'}
+                direction={sortConfig.direction}
                 onClick={() => requestSort('gamertag')}
               >
-                <div className="flex items-center">
-                  Player
-                  <SortIndicator column="gamertag" sortConfig={sortConfig} />
-                </div>
-              </th>
-              <th 
-                scope="col" 
-                className="px-6 py-3.5 text-left text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors duration-150"
+                Player
+              </TableSortLabel>
+            </TableCell>
+            <TableCell sortDirection={sortConfig.key === 'position' ? sortConfig.direction : false}>
+              <TableSortLabel
+                active={sortConfig.key === 'position'}
+                direction={sortConfig.direction}
                 onClick={() => requestSort('position')}
               >
-                <div className="flex items-center">
-                  Position
-                  <SortIndicator column="position" sortConfig={sortConfig} />
-                </div>
-              </th>
-              <th 
-                scope="col" 
-                className="px-6 py-3.5 text-left text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider"
-              >
-                Status
-              </th>
-            </tr>
-          </thead>
-          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-            {sortedAndFilteredPlayers.length > 0 ? (
-              sortedAndFilteredPlayers.map((player, index) => (
-                <tr 
-                  key={player.id} 
-                  className={`${index % 2 === 0 ? 'bg-white dark:bg-gray-800' : 'bg-gray-50 dark:bg-gray-700/30'} hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors duration-150`}
-                >
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center">
-                      <div className="flex-shrink-0 h-10 w-10 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-600 border border-gray-200 dark:border-gray-600">
-                        {player.avatar_url ? (
-                          <Image
-                            src={player.avatar_url}
-                            alt={player.gamertag}
-                            width={40}
-                            height={40}
-                            className="h-10 w-10 object-cover"
-                            unoptimized
-                          />
-                        ) : (
-                          <div className="h-full w-full flex items-center justify-center bg-gradient-to-br from-blue-500 to-blue-600 text-white font-medium">
-                            {player.gamertag.charAt(0).toUpperCase()}
-                          </div>
-                        )}
-                      </div>
-                      <div className="ml-4">
-                        <div className="text-sm font-medium text-gray-900 dark:text-white">
-                          {player.gamertag}
-                        </div>
-                        {(player.first_name || player.last_name) && (
-                          <div className="text-xs text-gray-500 dark:text-gray-400">
-                            {player.first_name} {player.last_name}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    {player.position ? (
-                      <span className="px-2.5 py-1 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200">
-                        {player.position}
-                      </span>
-                    ) : (
-                      <span className="text-sm text-gray-500 dark:text-gray-400">-</span>
-                    )}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    {getStatusBadge(player)}
-                  </td>
-                </tr>
-              ))
-            ) : (
-              <tr>
-                <td colSpan={6} className="px-6 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
+                Position
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedAndFilteredPlayers.length > 0 ? (
+            sortedAndFilteredPlayers.map((player) => (
+              <TableRow key={player.id} hover>
+                <TableCell>
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <Avatar src={player.avatar_url || undefined} sx={{ mr: 2 }}>
+                      {player.avatar_url ? '' : player.gamertag.charAt(0).toUpperCase()}
+                    </Avatar>
+                    <Box>
+                      <Typography variant="body2" fontWeight={500}>{player.gamertag}</Typography>
+                      {(player.first_name || player.last_name) && (
+                        <Typography variant="caption" color="text.secondary">
+                          {player.first_name} {player.last_name}
+                        </Typography>
+                      )}
+                    </Box>
+                  </Box>
+                </TableCell>
+                <TableCell>
+                  {player.position ? <Chip label={player.position} size="small" /> : <Typography variant="body2" color="text.secondary">-</Typography>}
+                </TableCell>
+                <TableCell>{getStatusBadge(player)}</TableCell>
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={3} align="center">
+                <Typography variant="body2" color="text.secondary">
                   {searchTerm ? 'No players match your search.' : 'No players found on the roster.'}
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-    </div>
+                </Typography>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </Paper>
   );
 }


### PR DESCRIPTION
## Summary
- add color mode context and improved theme provider
- sync dark mode toggle using MUI context
- redesign teams page with MUI Grid and Cards
- rewrite roster table using MUI table components

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687913dd8a788328bb604357ac5a6265